### PR TITLE
Storage op example ipynbs

### DIFF
--- a/notebooks/5-dkube_storage_op.ipynb
+++ b/notebooks/5-dkube_storage_op.ipynb
@@ -1,0 +1,395 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Install pipelines SDK"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Please wait till this cell completes and then run next cells. This just need to be run once per active kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: RELEASE_VERSION=1.0.0\n",
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "Collecting https://storage.googleapis.com/ml-pipeline/release/1.0.0/kfp.tar.gz\n",
+      "  Downloading https://storage.googleapis.com/ml-pipeline/release/1.0.0/kfp.tar.gz (122 kB)\n",
+      "\u001b[K     |████████████████████████████████| 122 kB 4.0 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: PyYAML in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (5.4.1)\n",
+      "Requirement already satisfied: google-cloud-storage>=1.13.0 in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (1.42.0)\n",
+      "Collecting kubernetes<12.0.0,>=8.0.0\n",
+      "  Downloading kubernetes-11.0.0-py3-none-any.whl (1.5 MB)\n",
+      "\u001b[K     |████████████████████████████████| 1.5 MB 14.1 MB/s eta 0:00:01\n",
+      "\u001b[?25hRequirement already satisfied: google-auth>=1.6.1 in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (1.34.0)\n",
+      "Requirement already satisfied: requests_toolbelt>=0.8.0 in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (0.9.1)\n",
+      "Requirement already satisfied: cloudpickle in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (1.6.0)\n",
+      "Requirement already satisfied: kfp-server-api<2.0.0,>=0.2.5 in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (1.6.0)\n",
+      "Requirement already satisfied: jsonschema>=3.0.1 in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (3.0.2)\n",
+      "Requirement already satisfied: tabulate in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (0.8.9)\n",
+      "Requirement already satisfied: click in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (7.1.2)\n",
+      "Requirement already satisfied: Deprecated in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (1.2.12)\n",
+      "Requirement already satisfied: strip-hints in /usr/local/lib/python3.6/dist-packages (from kfp==1.0.0) (0.1.10)\n",
+      "Requirement already satisfied: rsa<5,>=3.1.4 in /usr/local/lib/python3.6/dist-packages (from google-auth>=1.6.1->kfp==1.0.0) (4.7.2)\n",
+      "Requirement already satisfied: setuptools>=40.3.0 in /usr/local/lib/python3.6/dist-packages (from google-auth>=1.6.1->kfp==1.0.0) (41.2.0)\n",
+      "Requirement already satisfied: cachetools<5.0,>=2.0.0 in /usr/local/lib/python3.6/dist-packages (from google-auth>=1.6.1->kfp==1.0.0) (4.2.2)\n",
+      "Requirement already satisfied: six>=1.9.0 in /usr/local/lib/python3.6/dist-packages (from google-auth>=1.6.1->kfp==1.0.0) (1.16.0)\n",
+      "Requirement already satisfied: pyasn1-modules>=0.2.1 in /usr/local/lib/python3.6/dist-packages (from google-auth>=1.6.1->kfp==1.0.0) (0.2.8)\n",
+      "Requirement already satisfied: google-cloud-core<3.0dev,>=1.6.0 in /usr/local/lib/python3.6/dist-packages (from google-cloud-storage>=1.13.0->kfp==1.0.0) (1.7.2)\n",
+      "Requirement already satisfied: google-resumable-media<3.0dev,>=1.3.0 in /usr/local/lib/python3.6/dist-packages (from google-cloud-storage>=1.13.0->kfp==1.0.0) (1.3.3)\n",
+      "Requirement already satisfied: google-api-core<3.0dev,>=1.29.0 in /usr/local/lib/python3.6/dist-packages (from google-cloud-storage>=1.13.0->kfp==1.0.0) (1.31.1)\n",
+      "Requirement already satisfied: requests<3.0.0dev,>=2.18.0 in /usr/local/lib/python3.6/dist-packages (from google-cloud-storage>=1.13.0->kfp==1.0.0) (2.26.0)\n",
+      "Requirement already satisfied: pytz in /usr/local/lib/python3.6/dist-packages (from google-api-core<3.0dev,>=1.29.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (2021.1)\n",
+      "Requirement already satisfied: protobuf>=3.12.0 in /usr/local/lib/python3.6/dist-packages (from google-api-core<3.0dev,>=1.29.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (3.17.3)\n",
+      "Requirement already satisfied: googleapis-common-protos<2.0dev,>=1.6.0 in /usr/local/lib/python3.6/dist-packages (from google-api-core<3.0dev,>=1.29.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (1.53.0)\n",
+      "Requirement already satisfied: packaging>=14.3 in /usr/local/lib/python3.6/dist-packages (from google-api-core<3.0dev,>=1.29.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (21.0)\n",
+      "Requirement already satisfied: google-crc32c<2.0dev,>=1.0 in /usr/local/lib/python3.6/dist-packages (from google-resumable-media<3.0dev,>=1.3.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (1.1.2)\n",
+      "Requirement already satisfied: cffi>=1.0.0 in /usr/local/lib/python3.6/dist-packages (from google-crc32c<2.0dev,>=1.0->google-resumable-media<3.0dev,>=1.3.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (1.14.6)\n",
+      "Requirement already satisfied: pycparser in /usr/local/lib/python3.6/dist-packages (from cffi>=1.0.0->google-crc32c<2.0dev,>=1.0->google-resumable-media<3.0dev,>=1.3.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (2.20)\n",
+      "Requirement already satisfied: attrs>=17.4.0 in /usr/local/lib/python3.6/dist-packages (from jsonschema>=3.0.1->kfp==1.0.0) (19.2.0)\n",
+      "Requirement already satisfied: pyrsistent>=0.14.0 in /usr/local/lib/python3.6/dist-packages (from jsonschema>=3.0.1->kfp==1.0.0) (0.15.4)\n",
+      "Requirement already satisfied: urllib3>=1.15 in /usr/local/lib/python3.6/dist-packages (from kfp-server-api<2.0.0,>=0.2.5->kfp==1.0.0) (1.26.6)\n",
+      "Requirement already satisfied: python-dateutil in /usr/local/lib/python3.6/dist-packages (from kfp-server-api<2.0.0,>=0.2.5->kfp==1.0.0) (2.8.0)\n",
+      "Requirement already satisfied: certifi in /usr/local/lib/python3.6/dist-packages (from kfp-server-api<2.0.0,>=0.2.5->kfp==1.0.0) (2021.5.30)\n",
+      "Requirement already satisfied: websocket-client!=0.40.0,!=0.41.*,!=0.42.*,>=0.32.0 in /usr/local/lib/python3.6/dist-packages (from kubernetes<12.0.0,>=8.0.0->kfp==1.0.0) (1.2.1)\n",
+      "Requirement already satisfied: requests-oauthlib in /usr/local/lib/python3.6/dist-packages (from kubernetes<12.0.0,>=8.0.0->kfp==1.0.0) (1.3.0)\n",
+      "Requirement already satisfied: pyparsing>=2.0.2 in /usr/local/lib/python3.6/dist-packages (from packaging>=14.3->google-api-core<3.0dev,>=1.29.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (2.4.2)\n",
+      "Requirement already satisfied: pyasn1<0.5.0,>=0.4.6 in /usr/local/lib/python3.6/dist-packages (from pyasn1-modules>=0.2.1->google-auth>=1.6.1->kfp==1.0.0) (0.4.8)\n",
+      "Requirement already satisfied: idna<4,>=2.5 in /usr/lib/python3/dist-packages (from requests<3.0.0dev,>=2.18.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (2.6)\n",
+      "Requirement already satisfied: charset-normalizer~=2.0.0 in /usr/local/lib/python3.6/dist-packages (from requests<3.0.0dev,>=2.18.0->google-cloud-storage>=1.13.0->kfp==1.0.0) (2.0.4)\n",
+      "Requirement already satisfied: wrapt<2,>=1.10 in /usr/local/lib/python3.6/dist-packages (from Deprecated->kfp==1.0.0) (1.11.2)\n",
+      "Requirement already satisfied: oauthlib>=3.0.0 in /usr/local/lib/python3.6/dist-packages (from requests-oauthlib->kubernetes<12.0.0,>=8.0.0->kfp==1.0.0) (3.1.1)\n",
+      "Requirement already satisfied: wheel in /usr/lib/python3/dist-packages (from strip-hints->kfp==1.0.0) (0.30.0)\n",
+      "Building wheels for collected packages: kfp\n",
+      "  Building wheel for kfp (setup.py) ... \u001b[?25ldone\n",
+      "\u001b[?25h  Created wheel for kfp: filename=kfp-1.0.0-py3-none-any.whl size=168415 sha256=e052704fc98177443811a8f885a074a27c630e254ff809025dfea4d6698bdff7\n",
+      "  Stored in directory: /tmp/pip-ephem-wheel-cache-ul3ksxv6/wheels/4b/7c/e8/0e2908409b03b0bc529b8f927b57f44f01630c4b508d321d6b\n",
+      "Successfully built kfp\n",
+      "Installing collected packages: kubernetes, kfp\n",
+      "\u001b[33m  WARNING: The scripts dsl-compile and kfp are installed in '/home/ocdkube/.local/bin' which is not on PATH.\n",
+      "  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.\u001b[0m\n",
+      "Successfully installed kfp-1.0.0 kubernetes-11.0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "%env RELEASE_VERSION=1.0.0\n",
+    "!pip install https://storage.googleapis.com/ml-pipeline/release/${RELEASE_VERSION}/kfp.tar.gz --upgrade"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Import kfp pkgs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import kfp\n",
+    "import kfp.dsl as dsl\n",
+    "import kfp.compiler as compiler\n",
+    "from kubernetes import client as k8s_client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# List existing pipeline experiments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "existing_token = os.getenv(\"DKUBE_USER_ACCESS_TOKEN\")\n",
+    "client = kfp.Client(existing_token=existing_token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'experiments': [{'created_at': datetime.datetime(2021, 9, 5, 13, 34, 40, tzinfo=tzlocal()),\n",
+       "                  'description': None,\n",
+       "                  'id': '609fee28-4a55-414e-90a4-456591d1de63',\n",
+       "                  'name': 'Default',\n",
+       "                  'resource_references': [{'key': {'id': 'ocdkube',\n",
+       "                                                   'type': 'NAMESPACE'},\n",
+       "                                           'name': None,\n",
+       "                                           'relationship': 'OWNER'}],\n",
+       "                  'storage_state': 'STORAGESTATE_AVAILABLE'}],\n",
+       " 'next_page_token': None,\n",
+       " 'total_size': 1}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.list_experiments()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create a Dkube Storage experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a href=\"/pipeline/#/experiments/details/aab4d596-ffa7-4c54-bcb7-0667105b1ca9\" target=\"_blank\" >Experiment details</a>."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "dkube_store_experiment = client.create_experiment(name='Dkube - Storage pl')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define e2e Storage Pipeline with Dkube components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import kfp.dsl as dsl\n",
+    "from kfp import components\n",
+    "from kubernetes import client as k8s_client\n",
+    "\n",
+    "import os\n",
+    "import json\n",
+    "from random import randint\n",
+    "\n",
+    "components_url = \"/mnt/dkube/pipeline/components/\"\n",
+    "dkube_storage_op            = components.load_component_from_file(components_url + \"/storage/component.yaml\")\n",
+    "\n",
+    "@dsl.pipeline(\n",
+    "    name='storage',\n",
+    "    description='sample pipeline with dkube storage component'\n",
+    ")\n",
+    "def d3pipeline(\n",
+    "    #Dkube authentication token\n",
+    "    auth_token = os.getenv(\"DKUBE_USER_ACCESS_TOKEN\"),\n",
+    "    #Namespace to export the datasets\n",
+    "    namespace = os.getenv(\"USERNAME\"),\n",
+    "    command = 'export',\n",
+    "    #List of artifacts to export, format : <claimname>@<class>://<owner>:<datumname>/<version>\n",
+    "    #Class must be one of: [dataset, model, program]\n",
+    "    #To get the latest version use \"latest\" in place of <version>, otherwise use v1, v2, etc. (For program, use full commitid)\n",
+    "    #(Default version is \"latest\")\n",
+    "    input_volumes = json.dumps([\"mn-proj-3@program://mnist\"]),\n",
+    "    output_volumes = json.dumps([\"mn-data@dataset://mnist/v1\"]),\n",
+    "    intermediate_volume = 'temp-1'\n",
+    "    ):\n",
+    "\n",
+    "    \n",
+    "    store       = dkube_storage_op(command, auth_token, namespace, input_volumes=input_volumes,\n",
+    "                                   output_volumes=output_volumes, intermediate_volume=intermediate_volume)\n",
+    "#                                  )                                   "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compile and generate tar ball"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compiler.Compiler().compile(d3pipeline, 'dkube_storage_pl.tar.gz')\n",
+    "# Upload this generated tarball into the Pipelines UI"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create and Run Pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Click the dkube-training stage to see the enhanced Dkube Datascience dashboard, metrics and graphs. Click the dkube-viewer stage for the simple UI to test the model predecitions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### <font color=red> Fill the training_program, training_dataset and training_output_model with appropriate values in the next cell </font>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a href=\"/pipeline/#/runs/details/5c8a65dc-0268-4caf-833d-f123c9fe13d9\" target=\"_blank\" >Run details</a>."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "run = client.run_pipeline(dkube_store_experiment.id, 'dkube_storage_pipeline_1', 'dkube_storage_pl.tar.gz', params={})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Define Reclaim Pipeline with Dkube components"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@dsl.pipeline(\n",
+    "    name='reclaim',\n",
+    "    description='sample pipeline with dkube storage - reclaim component'\n",
+    ")\n",
+    "def d3_reclaim_pipeline(\n",
+    "    command = 'reclaim',\n",
+    "    #Dkube authentication token\n",
+    "    auth_token = os.getenv(\"DKUBE_USER_ACCESS_TOKEN\"),\n",
+    "    #Namespace of volumes to reclaim\n",
+    "    namespace = os.getenv(\"USERNAME\"),\n",
+    "    # UID relating all volumes\n",
+    "    uid = '5c8a65dc-0268-4caf-833d-f123c9fe13d9'\n",
+    "    ):\n",
+    "\n",
+    "    store       = dkube_storage_op(command, auth_token, namespace, uid=uid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "compiler.Compiler().compile(d3_reclaim_pipeline, 'dkube_storage_reclaim_pl.tar.gz')\n",
+    "# Upload this generated tarball into the Pipelines UI"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a href=\"/pipeline/#/runs/details/586cad4f-065b-4c97-9437-95b3ebb2f275\" target=\"_blank\" >Run details</a>."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "run = client.run_pipeline(dkube_store_experiment.id, 'dkube_storage_reclaim_pipeline_1', 'dkube_storage_reclaim_pl.tar.gz', params={})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/6-mnist_storage_op.ipynb
+++ b/notebooks/6-mnist_storage_op.ipynb
@@ -1,0 +1,277 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import kfp\n",
+    "from kfp import dsl\n",
+    "import os\n",
+    "import kfp.compiler as compiler\n",
+    "from kubernetes.client.models import V1EnvVar\n",
+    "from kubernetes import client as k8s_client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# List existing pipeline experiments"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "existing_token = os.getenv(\"DKUBE_USER_ACCESS_TOKEN\")\n",
+    "client = kfp.Client(existing_token=existing_token)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'experiments': [{'created_at': datetime.datetime(2021, 9, 5, 13, 34, 40, tzinfo=tzlocal()),\n",
+       "                  'description': None,\n",
+       "                  'id': '609fee28-4a55-414e-90a4-456591d1de63',\n",
+       "                  'name': 'Default',\n",
+       "                  'resource_references': [{'key': {'id': 'ocdkube',\n",
+       "                                                   'type': 'NAMESPACE'},\n",
+       "                                           'name': None,\n",
+       "                                           'relationship': 'OWNER'}],\n",
+       "                  'storage_state': 'STORAGESTATE_AVAILABLE'},\n",
+       "                 {'created_at': datetime.datetime(2021, 9, 6, 14, 21, 13, tzinfo=tzlocal()),\n",
+       "                  'description': None,\n",
+       "                  'id': 'aab4d596-ffa7-4c54-bcb7-0667105b1ca9',\n",
+       "                  'name': 'Dkube - Storage pl',\n",
+       "                  'resource_references': [{'key': {'id': 'ocdkube',\n",
+       "                                                   'type': 'NAMESPACE'},\n",
+       "                                           'name': None,\n",
+       "                                           'relationship': 'OWNER'}],\n",
+       "                  'storage_state': 'STORAGESTATE_AVAILABLE'}],\n",
+       " 'next_page_token': None,\n",
+       " 'total_size': 2}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "client.list_experiments()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create a Dkube Storage experiment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a href=\"/pipeline/#/experiments/details/aab4d596-ffa7-4c54-bcb7-0667105b1ca9\" target=\"_blank\" >Experiment details</a>."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "dkube_store_experiment = client.create_experiment(name='Dkube - Storage pl')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class ContainerOp(kfp.dsl.ContainerOp):\n",
+    "    def __init__(self, **kwargs):\n",
+    "        super().__init__(**kwargs)\n",
+    "        self.add_pod_label(name=\"dkube.garbagecollect\", value=\"true\")\n",
+    "        self.add_pod_label(name=\"dkube.garbagecollect.policy\", value=\"all\")\n",
+    "        self.add_pod_label(name=\"runid\", value=\"{{pod.name}}\")\n",
+    "        self.add_pod_label(name=\"wfid\", value=\"{{workflow.uid}}\")\n",
+    "\n",
+    "def reclaim(uid, namespace, auth_token):\n",
+    "    return ContainerOp(\n",
+    "       name=\"reclaim_repos\",\n",
+    "       image=\"ocdr/dkubepl:2.3.0.6\",\n",
+    "       command=[\n",
+    "           \"dkubepl\",\n",
+    "           \"storage\",\n",
+    "           \"--action\",\n",
+    "           \"reclaim\",\n",
+    "           \"--token\",\n",
+    "           auth_token,\n",
+    "           \"--namespace\",\n",
+    "           namespace,\n",
+    "           \"--uid\",\n",
+    "           uid\n",
+    "       ],\n",
+    "    )\n",
+    "    \n",
+    "    \n",
+    "        \n",
+    "@kfp.dsl.pipeline(\n",
+    "    name=\"MNIST Storage pipeline\",\n",
+    "    description=\"A pipline showing how to use storage component\",\n",
+    ")\n",
+    "def storage_pipeline(\n",
+    "    #Dkube authentication token\n",
+    "    auth_token = os.getenv(\"DKUBE_USER_ACCESS_TOKEN\"),\n",
+    "    #Namespace to export the datasets\n",
+    "    namespace = os.getenv(\"USERNAME\"),\n",
+    "    #List of artifacts to export, format : <claimname>@<class>://<owner>:<datumname>/<version>\n",
+    "    #Class must be one of: [dataset, model, program]\n",
+    "    #To get the latest version use \"latest\" in place of <version>, otherwise use v1, v2, etc. (For program, use full commitid)\n",
+    "    #(Default version is \"latest\")\n",
+    "    dataset = \"mnist/v1\",\n",
+    "    program = \"mnist\",\n",
+    "    model = \"mnist\"\n",
+    "    ):\n",
+    "    \n",
+    "    reclaim_task = reclaim(\"{{workflow.uid}}\", namespace, auth_token) \n",
+    "    with dsl.ExitHandler(reclaim_task):\n",
+    "        program_volume_claim = \"{{workflow.uid}}-mn-project\"\n",
+    "        dataset_volume_claim = \"{{workflow.uid}}-mn-dataset\"\n",
+    "        model_volume_claim = \"{{workflow.uid}}-mn-model\"\n",
+    "        program_volume = program_volume_claim + \"@program://\" + str(program)\n",
+    "        dataset_volume = dataset_volume_claim + \"@dataset://\" + str(dataset)\n",
+    "        model_volume = model_volume_claim + \"@model://\" + str(model)\n",
+    "        input_volumes = json.dumps([program_volume, dataset_volume])\n",
+    "        output_volumes = json.dumps([model_volume])\n",
+    "        \n",
+    "        pipelineConfig = kfp.dsl.PipelineConf()\n",
+    "        pipelineConfig.set_image_pull_policy(\"Always\")\n",
+    "        \n",
+    "        export = ContainerOp(\n",
+    "            name=\"export_repos\",\n",
+    "            image=\"ocdr/dkubepl:2.3.0.6\",\n",
+    "            command=[\n",
+    "                \"dkubepl\",\n",
+    "                \"storage\",\n",
+    "                \"--action\",\n",
+    "                \"export\",\n",
+    "                \"--token\",\n",
+    "                auth_token,\n",
+    "                \"--namespace\",\n",
+    "                namespace,\n",
+    "                \"--input_volumes\",\n",
+    "                input_volumes,\n",
+    "                \"--output_volumes\",\n",
+    "                output_volumes,\n",
+    "                \"--runid\",\n",
+    "                '{{pod.name}}',\n",
+    "                \"--wfid\",\n",
+    "                \"{{workflow.uid}}\",\n",
+    "            ],\n",
+    "        )\n",
+    "    \n",
+    "        train = ContainerOp(name='train', image='ocdr/d3-datascience-tf-cpu:v1.14', command=\"bash\", arguments=[\"-c\", \"cd /opt/dkube/project/; python mnist/train.py\"]).add_volume(k8s_client.V1Volume(name='mnist-project', persistent_volume_claim=k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name=program_volume_claim))).add_volume_mount(k8s_client.V1VolumeMount(mount_path='/opt/dkube/project', name='mnist-project')).add_volume(k8s_client.V1Volume(name='mnist-dataset', persistent_volume_claim=k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name=dataset_volume_claim))).add_volume_mount(k8s_client.V1VolumeMount(mount_path='/mnist', name='mnist-dataset')).add_volume(k8s_client.V1Volume(name='mnist-model', persistent_volume_claim=k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name=model_volume_claim))).\tadd_volume_mount(k8s_client.V1VolumeMount(mount_path='/model', name='mnist-model'))\n",
+    "       # train = ContainerOp(name='train', image='ocdr/d3-datascience-tf-cpu:v1.14', command=\"bash\", arguments=[\"-c\", \"sleep infinity\"]).add_volume(k8s_client.V1Volume(name='mnist-project', persistent_volume_claim=k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name=program_volume_claim))).add_volume_mount(k8s_client.V1VolumeMount(mount_path='/opt/dkube/project', name='mnist-project')).add_volume(k8s_client.V1Volume(name='mnist-dataset', persistent_volume_claim=k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name=dataset_volume_claim))).add_volume_mount(k8s_client.V1VolumeMount(mount_path='/opt/dkube/input', name='mnist-dataset')).add_volume(k8s_client.V1Volume(name='mnist-model', persistent_volume_claim=k8s_client.V1PersistentVolumeClaimVolumeSource(claim_name=model_volume_claim))).\tadd_volume_mount(k8s_client.V1VolumeMount(mount_path='/opt/dkube/output', name='mnist-model'))\n",
+    "        #train.add_pod_label(name: str, value: str)\n",
+    "\n",
+    "        train.after(export)\n",
+    "   \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/lib/python3.6/dist-packages/kfp/dsl/_container_op.py:1157: FutureWarning: Please create reusable components instead of constructing ContainerOp instances directly. Reusable components are shareable, portable and have compatibility and support guarantees. Please see the documentation: https://www.kubeflow.org/docs/pipelines/sdk/component-development/#writing-your-component-definition-file The components can be created manually (or, in case of python, using kfp.components.create_component_from_func or func_to_container_op) and then loaded using kfp.components.load_component_from_file, load_component_from_uri or load_component_from_text: https://kubeflow-pipelines.readthedocs.io/en/stable/source/kfp.components.html#kfp.components.load_component_from_file\n",
+      "  category=FutureWarning,\n"
+     ]
+    }
+   ],
+   "source": [
+    "compiler.Compiler().compile(storage_pipeline, 'dkube_storage_pl.tar.gz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<a href=\"/pipeline/#/runs/details/6300b3dd-d7f0-42bb-ba8c-db02b7e6a682\" target=\"_blank\" >Run details</a>."
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "run = client.run_pipeline(dkube_store_experiment.id, 'dkube_storage_pipeline_1', 'dkube_storage_pl.tar.gz', params={})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Fixes https://github.com/oneconvergence/gpuaas/issues/7774
2 example ipynb files for storage op:

> dkube-storage-op.ipynb - Separate export and reclaim stages in 2 pipelines. To be executed manually.
> mnist-storage-op.ipynb - Mnist training outside dkube by exporting dkube repos using storage op.